### PR TITLE
Refactor: catalog configuration

### DIFF
--- a/src/dagster_pyiceberg/__init__.py
+++ b/src/dagster_pyiceberg/__init__.py
@@ -3,10 +3,7 @@ from typing import Sequence
 # from dagster._core.libraries import DagsterLibraryRegistry
 from dagster._core.storage.db_io_manager import DbTypeHandler
 
-from dagster_pyiceberg.config import (
-    IcebergRestCatalogConfig as IcebergRestCatalogConfig,
-)
-from dagster_pyiceberg.config import IcebergSqlCatalogConfig as IcebergSqlCatalogConfig
+from dagster_pyiceberg.config import IcebergCatalogConfig as IcebergCatalogConfig
 from dagster_pyiceberg.handler import IcebergDaftTypeHandler as IcebergDaftTypeHandler
 from dagster_pyiceberg.handler import (
     IcebergPolarsTypeHandler as IcebergPolarsTypeHandler,

--- a/src/dagster_pyiceberg/config.py
+++ b/src/dagster_pyiceberg/config.py
@@ -1,34 +1,8 @@
-import sys
 from typing import Any, Dict
 
 from dagster import Config
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
-
-class _IcebergCatalogBaseConfig(Config):
+class IcebergCatalogConfig(Config):
 
     properties: Dict[str, Any]
-
-
-class IcebergSqlCatalogConfig(_IcebergCatalogBaseConfig):
-
-    type: Literal["sql"] = "sql"
-
-
-class IcebergRestCatalogConfig(_IcebergCatalogBaseConfig):
-
-    type: Literal["rest"] = "rest"
-
-
-# Options (not yet covered)
-#  Overwrite partition spec (or not)
-#  Update schemas (or fail)
-
-# Metadata (not yet covered)
-#  Sort order (metadata)
-#  Partition_expr mapping s.a. dagster-deltalake (metadata)
-#  Transforms (metadata)

--- a/src/dagster_pyiceberg/io_manager.py
+++ b/src/dagster_pyiceberg/io_manager.py
@@ -148,7 +148,6 @@ class IcebergIOManager(ConfigurableIOManagerFactory):
 
     name: str = Field(description="The name of the iceberg catalog.")
     config: IcebergCatalogConfig = Field(
-        discriminator="type",
         description="Additional configuration properties for the iceberg catalog.",
     )
     schema_: Optional[str] = Field(

--- a/src/dagster_pyiceberg/io_manager.py
+++ b/src/dagster_pyiceberg/io_manager.py
@@ -1,16 +1,7 @@
 import enum
 from abc import abstractmethod
 from contextlib import contextmanager  # noqa
-from typing import (  # noqa
-    Dict,
-    Iterator,
-    Optional,
-    Sequence,
-    Type,
-    TypedDict,
-    Union,
-    cast,
-)
+from typing import Dict, Iterator, Optional, Sequence, Type, TypedDict, cast  # noqa
 
 from dagster import OutputContext
 from dagster._config.pythonic_config import ConfigurableIOManagerFactory
@@ -23,14 +14,10 @@ from dagster._core.storage.db_io_manager import (
     TableSlice,
 )
 from pydantic import Field
-from pyiceberg.catalog.rest import RestCatalog
-from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.catalog import Catalog, load_catalog
 
 from dagster_pyiceberg._db_io_manager import CustomDbIOManager
-from dagster_pyiceberg.config import (  # noqa
-    IcebergRestCatalogConfig,
-    IcebergSqlCatalogConfig,
-)
+from dagster_pyiceberg.config import IcebergCatalogConfig  # noqa
 from dagster_pyiceberg.handler import CatalogTypes
 
 
@@ -54,35 +41,12 @@ class _IcebergCatalogProperties(TypedDict):
     properties: Dict[str, str]
 
 
-class _IcebergMetastoreCatalogConfig(TypedDict, total=False):
-
-    sql: _IcebergCatalogProperties
-    rest: _IcebergCatalogProperties
-
-
 class _IcebergTableIOManagerResourceConfig(TypedDict):
 
     name: str
-    config: _IcebergMetastoreCatalogConfig
+    config: _IcebergCatalogProperties
     partition_spec_update_mode: PartitionSpecUpdateMode
     schema_update_mode: SchemaUpdateMode
-
-
-def _connect_to_catalog(
-    name: str,
-    config: _IcebergMetastoreCatalogConfig,
-) -> CatalogTypes:
-    """Connect to the iceberg catalog."""
-
-    if "sql" in config:
-        catalog = SqlCatalog(name=name, **config["sql"]["properties"])
-    elif "rest" in config:
-        catalog = RestCatalog(name=name, **config["rest"]["properties"])
-    else:
-        raise NotImplementedError(
-            f"Catalog type '{next(iter(config.keys()))}' not implemented"
-        )
-    return catalog
 
 
 class IcebergDbClient(DbClient):
@@ -115,12 +79,12 @@ class IcebergDbClient(DbClient):
 
     @staticmethod
     @contextmanager
-    def connect(context, table_slice: TableSlice) -> Iterator[CatalogTypes]:
+    def connect(context, table_slice: TableSlice) -> Iterator[Catalog]:
         resource_config = cast(
             _IcebergTableIOManagerResourceConfig, context.resource_config
         )
-        yield _connect_to_catalog(
-            name=resource_config["name"], config=resource_config["config"]
+        yield load_catalog(
+            name=resource_config["name"], **resource_config["config"]["properties"]
         )
 
 
@@ -183,7 +147,7 @@ class IcebergIOManager(ConfigurableIOManagerFactory):
     """
 
     name: str = Field(description="The name of the iceberg catalog.")
-    config: Union[IcebergSqlCatalogConfig, IcebergRestCatalogConfig] = Field(
+    config: IcebergCatalogConfig = Field(
         discriminator="type",
         description="Additional configuration properties for the iceberg catalog.",
     )

--- a/src/dagster_pyiceberg/resource.py
+++ b/src/dagster_pyiceberg/resource.py
@@ -52,5 +52,5 @@ class IcebergTableResource(ConfigurableResource):
 
     def load(self) -> Table:
         config_ = self.config.model_dump()
-        catalog = load_catalog(name=self.name, **config_["config"]["properties"])
+        catalog = load_catalog(name=self.name, **config_["properties"])
         return catalog.load_table(identifier="%s.%s" % (self.schema_, self.table))

--- a/src/dagster_pyiceberg/resource.py
+++ b/src/dagster_pyiceberg/resource.py
@@ -1,16 +1,11 @@
-from typing import Optional, Union, cast
+from typing import Optional
 
 from dagster import ConfigurableResource
 from pydantic import Field
+from pyiceberg.catalog import load_catalog
 from pyiceberg.table import Table
 
-from dagster_pyiceberg.config import IcebergRestCatalogConfig, IcebergSqlCatalogConfig
-from dagster_pyiceberg.io_manager import (
-    _connect_to_catalog,
-    _IcebergMetastoreCatalogConfig,
-)
-
-SupportedCatalogConfigs = Union[IcebergRestCatalogConfig, IcebergSqlCatalogConfig]
+from dagster_pyiceberg.config import IcebergCatalogConfig
 
 
 class IcebergTableResource(ConfigurableResource):
@@ -39,8 +34,7 @@ class IcebergTableResource(ConfigurableResource):
     """
 
     name: str = Field(description="The name of the iceberg catalog.")
-    config: SupportedCatalogConfigs = Field(
-        discriminator="type",
+    config: IcebergCatalogConfig = Field(
         description="Additional configuration properties for the iceberg catalog.",
     )
     table: str = Field(
@@ -58,8 +52,5 @@ class IcebergTableResource(ConfigurableResource):
 
     def load(self) -> Table:
         config_ = self.config.model_dump()
-        config_parsed = {config_["type"]: {"properties": config_["properties"]}}
-        catalog = _connect_to_catalog(
-            name=self.name, config=cast(_IcebergMetastoreCatalogConfig, config_parsed)
-        )
+        catalog = load_catalog(name=self.name, **config_["config"]["properties"])
         return catalog.load_table(identifier="%s.%s" % (self.schema_, self.table))

--- a/tests/_db_io_manager/test_db_io_manager.py
+++ b/tests/_db_io_manager/test_db_io_manager.py
@@ -27,7 +27,7 @@ from dagster import (
     materialize,
 )
 
-from dagster_pyiceberg import IcebergPyarrowIOManager, IcebergSqlCatalogConfig
+from dagster_pyiceberg import IcebergCatalogConfig, IcebergPyarrowIOManager
 
 
 @pytest.fixture
@@ -36,7 +36,7 @@ def io_manager(
 ) -> IcebergPyarrowIOManager:
     return IcebergPyarrowIOManager(
         name=catalog_name,
-        config=IcebergSqlCatalogConfig(properties=catalog_config_properties),
+        config=IcebergCatalogConfig(properties=catalog_config_properties),
         schema=namespace,
         partition_spec_update_mode="error",
         db_io_manager="custom",

--- a/tests/_utils/conftest.py
+++ b/tests/_utils/conftest.py
@@ -8,7 +8,7 @@ from pyiceberg import schema as iceberg_schema
 from pyiceberg import table as iceberg_table
 from pyiceberg import transforms
 from pyiceberg import types as T
-from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.catalog import Catalog
 
 
 @pytest.fixture()
@@ -119,14 +119,14 @@ def table_partitioned_update_identifier(
 
 @pytest.fixture(scope="function", autouse=True)
 def create_table_in_catalog(
-    catalog: SqlCatalog, table_identifier: str, data_schema: pa.Schema
+    catalog: Catalog, table_identifier: str, data_schema: pa.Schema
 ):
     catalog.create_table(table_identifier, schema=data_schema)
 
 
 @pytest.fixture(scope="function", autouse=True)
 def create_partitioned_table_in_catalog(
-    catalog: SqlCatalog, table_partitioned_identifier: str, data_schema: pa.Schema
+    catalog: Catalog, table_partitioned_identifier: str, data_schema: pa.Schema
 ):
     partitioned_table = catalog.create_table(
         table_partitioned_identifier, schema=data_schema
@@ -146,7 +146,7 @@ def create_partitioned_table_in_catalog(
 
 @pytest.fixture(scope="function", autouse=True)
 def create_partitioned_update_table_in_catalog(
-    catalog: SqlCatalog,
+    catalog: Catalog,
     table_partitioned_update_identifier: str,
     data_schema: pa.Schema,
 ):
@@ -168,7 +168,7 @@ def create_partitioned_update_table_in_catalog(
 
 @pytest.fixture(scope="function", autouse=True)
 def append_data_to_table(
-    create_table_in_catalog, catalog: SqlCatalog, table_identifier: str, data: pa.Table
+    create_table_in_catalog, catalog: Catalog, table_identifier: str, data: pa.Table
 ):
     catalog.load_table(table_identifier).append(data)
 
@@ -176,7 +176,7 @@ def append_data_to_table(
 @pytest.fixture(scope="function", autouse=True)
 def append_data_to_partitioned_table(
     create_partitioned_table_in_catalog,
-    catalog: SqlCatalog,
+    catalog: Catalog,
     table_partitioned_identifier: str,
     data: pa.Table,
 ):
@@ -186,7 +186,7 @@ def append_data_to_partitioned_table(
 @pytest.fixture(scope="function")
 def append_data_to_partitioned_update_table(
     create_partitioned_update_table_in_catalog,
-    catalog: SqlCatalog,
+    catalog: Catalog,
     table_partitioned_update_identifier: str,
     data: pa.Table,
 ):
@@ -194,19 +194,19 @@ def append_data_to_partitioned_update_table(
 
 
 @pytest.fixture(scope="function")
-def table(catalog: SqlCatalog, table_identifier: str) -> iceberg_table.Table:
+def table(catalog: Catalog, table_identifier: str) -> iceberg_table.Table:
     return catalog.load_table(table_identifier)
 
 
 @pytest.fixture(scope="function")
 def table_partitioned(
-    catalog: SqlCatalog, table_partitioned_identifier: str
+    catalog: Catalog, table_partitioned_identifier: str
 ) -> iceberg_table.Table:
     return catalog.load_table(table_partitioned_identifier)
 
 
 @pytest.fixture(scope="function")
 def table_partitioned_update(
-    catalog: SqlCatalog, table_partitioned_update_identifier: str
+    catalog: Catalog, table_partitioned_update_identifier: str
 ) -> iceberg_table.Table:
     return catalog.load_table(table_partitioned_update_identifier)

--- a/tests/_utils/test_io.py
+++ b/tests/_utils/test_io.py
@@ -7,12 +7,12 @@ import pytest
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.storage.db_io_manager import TablePartitionDimension, TableSlice
 from pyiceberg import expressions as E
-from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.catalog import Catalog
 
 from dagster_pyiceberg._utils import io
 
 
-def test_table_writer(namespace: str, catalog: SqlCatalog, data: pa.Table):
+def test_table_writer(namespace: str, catalog: Catalog, data: pa.Table):
     table_ = "handler_data_table_writer"
     identifier_ = f"{namespace}.{table_}"
     io.table_writer(
@@ -43,7 +43,7 @@ def test_table_writer(namespace: str, catalog: SqlCatalog, data: pa.Table):
     )
 
 
-def test_table_writer_partitioned(namespace: str, catalog: SqlCatalog, data: pa.Table):
+def test_table_writer_partitioned(namespace: str, catalog: Catalog, data: pa.Table):
     # Works similar to # https://docs.dagster.io/integrations/deltalake/reference#storing-multi-partitioned-assets
     # Need to subset the data.
     table_ = "handler_data_table_writer_partitioned"
@@ -76,7 +76,7 @@ def test_table_writer_partitioned(namespace: str, catalog: SqlCatalog, data: pa.
 
 
 def test_table_writer_multi_partitioned(
-    namespace: str, catalog: SqlCatalog, data: pa.Table
+    namespace: str, catalog: Catalog, data: pa.Table
 ):
     # Works similar to # https://docs.dagster.io/integrations/deltalake/reference#storing-multi-partitioned-assets
     # Need to subset the data.
@@ -115,7 +115,7 @@ def test_table_writer_multi_partitioned(
 
 
 def test_table_writer_multi_partitioned_update(
-    namespace: str, catalog: SqlCatalog, data: pa.Table
+    namespace: str, catalog: Catalog, data: pa.Table
 ):
     # Works similar to # https://docs.dagster.io/integrations/deltalake/reference#storing-multi-partitioned-assets
     # Need to subset the data.
@@ -167,7 +167,7 @@ def test_table_writer_multi_partitioned_update(
 
 
 def test_table_writer_multi_partitioned_update_partition_spec_change(
-    namespace: str, warehouse_path: str, catalog: SqlCatalog, data: pa.Table
+    namespace: str, warehouse_path: str, catalog: Catalog, data: pa.Table
 ):
     table_ = "handler_data_table_writer_multi_partitioned_update_partition_spec_change"
     identifier_ = f"{namespace}.{table_}"
@@ -230,7 +230,7 @@ def test_table_writer_multi_partitioned_update_partition_spec_change(
 
 
 def test_table_writer_multi_partitioned_update_partition_spec_error(
-    namespace: str, catalog: SqlCatalog, data: pa.Table
+    namespace: str, catalog: Catalog, data: pa.Table
 ):
     table_ = "handler_data_multi_partitioned_update_partition_spec_error"
     io.table_writer(
@@ -284,7 +284,7 @@ def test_table_writer_multi_partitioned_update_partition_spec_error(
 
 
 def test_iceberg_table_writer_with_table_properties(
-    namespace: str, catalog: SqlCatalog, data: pa.Table
+    namespace: str, catalog: Catalog, data: pa.Table
 ):
     table_ = "handler_data_iceberg_table_writer_with_table_properties"
     identifier_ = f"{namespace}.{table_}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterator
 import psycopg2
 import pyarrow as pa
 import pytest
-from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.catalog import Catalog, load_catalog
 from testcontainers.postgres import PostgresContainer
 
 postgres = PostgresContainer("postgres:17-alpine")
@@ -77,15 +77,15 @@ def catalog_name() -> str:
 
 
 @pytest.fixture(scope="function")
-def catalog(catalog_name: str, catalog_config_properties: Dict[str, str]) -> SqlCatalog:
-    return SqlCatalog(
-        catalog_name,
+def catalog(catalog_name: str, catalog_config_properties: Dict[str, str]) -> Catalog:
+    return load_catalog(
+        name=catalog_name,
         **catalog_config_properties,
     )
 
 
 @pytest.fixture(scope="function", autouse=True)
-def namespace(catalog: SqlCatalog) -> str:
+def namespace(catalog: Catalog) -> str:
     catalog.create_namespace("pytest")
     return "pytest"
 

--- a/tests/io_managers/test_arrow_io_manager.py
+++ b/tests/io_managers/test_arrow_io_manager.py
@@ -12,9 +12,9 @@ from dagster import (
     asset,
     materialize,
 )
-from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.catalog import Catalog
 
-from dagster_pyiceberg import IcebergPyarrowIOManager, IcebergSqlCatalogConfig
+from dagster_pyiceberg import IcebergCatalogConfig, IcebergPyarrowIOManager
 
 
 @pytest.fixture
@@ -23,7 +23,7 @@ def io_manager(
 ) -> IcebergPyarrowIOManager:
     return IcebergPyarrowIOManager(
         name=catalog_name,
-        config=IcebergSqlCatalogConfig(properties=catalog_config_properties),
+        config=IcebergCatalogConfig(properties=catalog_config_properties),
         schema=namespace,
         partition_spec_update_mode="error",
     )
@@ -133,7 +133,7 @@ def multi_partitioned(context: AssetExecutionContext) -> pa.Table:
 def test_iceberg_io_manager_with_assets(
     asset_b_df_table_identifier: str,
     asset_b_plus_one_table_identifier: str,
-    catalog: SqlCatalog,
+    catalog: Catalog,
     io_manager: IcebergPyarrowIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
@@ -153,7 +153,7 @@ def test_iceberg_io_manager_with_assets(
 
 def test_iceberg_io_manager_with_daily_partitioned_assets(
     asset_daily_partitioned_table_identifier: str,
-    catalog: SqlCatalog,
+    catalog: Catalog,
     io_manager: IcebergPyarrowIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
@@ -183,7 +183,7 @@ def test_iceberg_io_manager_with_daily_partitioned_assets(
 
 def test_iceberg_io_manager_with_hourly_partitioned_assets(
     asset_hourly_partitioned_table_identifier: str,
-    catalog: SqlCatalog,
+    catalog: Catalog,
     io_manager: IcebergPyarrowIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
@@ -213,7 +213,7 @@ def test_iceberg_io_manager_with_hourly_partitioned_assets(
 
 def test_iceberg_io_manager_with_multipartitioned_assets(
     asset_multi_partitioned_table_identifier: str,
-    catalog: SqlCatalog,
+    catalog: Catalog,
     io_manager: IcebergPyarrowIOManager,
 ):
     resource_defs = {"io_manager": io_manager}

--- a/tests/io_managers/test_daft_io_manager.py
+++ b/tests/io_managers/test_daft_io_manager.py
@@ -12,9 +12,9 @@ from dagster import (
     asset,
     materialize,
 )
-from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.catalog import Catalog
 
-from dagster_pyiceberg import IcebergDaftIOManager, IcebergSqlCatalogConfig
+from dagster_pyiceberg import IcebergCatalogConfig, IcebergDaftIOManager
 
 
 @pytest.fixture
@@ -23,7 +23,7 @@ def io_manager(
 ) -> IcebergDaftIOManager:
     return IcebergDaftIOManager(
         name=catalog_name,
-        config=IcebergSqlCatalogConfig(properties=catalog_config_properties),
+        config=IcebergCatalogConfig(properties=catalog_config_properties),
         schema=namespace,
         partition_spec_update_mode="error",
     )
@@ -133,7 +133,7 @@ def multi_partitioned(context: AssetExecutionContext) -> da.DataFrame:
 def test_iceberg_io_manager_with_assets(
     asset_b_df_table_identifier: str,
     asset_b_plus_one_table_identifier: str,
-    catalog: SqlCatalog,
+    catalog: Catalog,
     io_manager: IcebergDaftIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
@@ -153,7 +153,7 @@ def test_iceberg_io_manager_with_assets(
 
 def test_iceberg_io_manager_with_daily_partitioned_assets(
     asset_daily_partitioned_table_identifier: str,
-    catalog: SqlCatalog,
+    catalog: Catalog,
     io_manager: IcebergDaftIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
@@ -183,7 +183,7 @@ def test_iceberg_io_manager_with_daily_partitioned_assets(
 
 def test_iceberg_io_manager_with_hourly_partitioned_assets(
     asset_hourly_partitioned_table_identifier: str,
-    catalog: SqlCatalog,
+    catalog: Catalog,
     io_manager: IcebergDaftIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
@@ -213,7 +213,7 @@ def test_iceberg_io_manager_with_hourly_partitioned_assets(
 
 def test_iceberg_io_manager_with_multipartitioned_assets(
     asset_multi_partitioned_table_identifier: str,
-    catalog: SqlCatalog,
+    catalog: Catalog,
     io_manager: IcebergDaftIOManager,
 ):
     resource_defs = {"io_manager": io_manager}

--- a/tests/io_managers/test_polars_io_manager.py
+++ b/tests/io_managers/test_polars_io_manager.py
@@ -12,9 +12,9 @@ from dagster import (
     asset,
     materialize,
 )
-from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.catalog import Catalog
 
-from dagster_pyiceberg import IcebergPolarsIOManager, IcebergSqlCatalogConfig
+from dagster_pyiceberg import IcebergCatalogConfig, IcebergPolarsIOManager
 
 
 @pytest.fixture
@@ -23,7 +23,7 @@ def io_manager(
 ) -> IcebergPolarsIOManager:
     return IcebergPolarsIOManager(
         name=catalog_name,
-        config=IcebergSqlCatalogConfig(properties=catalog_config_properties),
+        config=IcebergCatalogConfig(properties=catalog_config_properties),
         schema=namespace,
         partition_spec_update_mode="error",
     )
@@ -134,7 +134,7 @@ def multi_partitioned(context: AssetExecutionContext) -> pl.DataFrame:
 def test_iceberg_io_manager_with_assets(
     asset_b_df_table_identifier: str,
     asset_b_plus_one_table_identifier: str,
-    catalog: SqlCatalog,
+    catalog: Catalog,
     io_manager: IcebergPolarsIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
@@ -154,7 +154,7 @@ def test_iceberg_io_manager_with_assets(
 
 def test_iceberg_io_manager_with_daily_partitioned_assets(
     asset_daily_partitioned_table_identifier: str,
-    catalog: SqlCatalog,
+    catalog: Catalog,
     io_manager: IcebergPolarsIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
@@ -184,7 +184,7 @@ def test_iceberg_io_manager_with_daily_partitioned_assets(
 
 def test_iceberg_io_manager_with_hourly_partitioned_assets(
     asset_hourly_partitioned_table_identifier: str,
-    catalog: SqlCatalog,
+    catalog: Catalog,
     io_manager: IcebergPolarsIOManager,
 ):
     resource_defs = {"io_manager": io_manager}
@@ -214,7 +214,7 @@ def test_iceberg_io_manager_with_hourly_partitioned_assets(
 
 def test_iceberg_io_manager_with_multipartitioned_assets(
     asset_multi_partitioned_table_identifier: str,
-    catalog: SqlCatalog,
+    catalog: Catalog,
     io_manager: IcebergPolarsIOManager,
 ):
     resource_defs = {"io_manager": io_manager}

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -3,10 +3,10 @@ from typing import Dict
 import pyarrow as pa
 import pytest
 from dagster import asset, materialize
-from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.catalog import Catalog
 from pyiceberg.table import Table
 
-from dagster_pyiceberg import IcebergSqlCatalogConfig, IcebergTableResource
+from dagster_pyiceberg import IcebergCatalogConfig, IcebergTableResource
 
 
 @pytest.fixture(scope="module")
@@ -21,14 +21,14 @@ def table_identifier(namespace: str, table_name: str) -> str:
 
 @pytest.fixture(scope="function", autouse=True)
 def create_table_in_catalog(
-    catalog: SqlCatalog, table_identifier: str, data_schema: pa.Schema
+    catalog: Catalog, table_identifier: str, data_schema: pa.Schema
 ):
     catalog.create_table(table_identifier, data_schema)
 
 
 @pytest.fixture(scope="function", autouse=True)
 def iceberg_table(
-    create_table_in_catalog, catalog: SqlCatalog, table_identifier: str
+    create_table_in_catalog, catalog: Catalog, table_identifier: str
 ) -> Table:
     return catalog.load_table(table_identifier)
 
@@ -47,7 +47,7 @@ def pyiceberg_table_resource(
 ) -> IcebergTableResource:
     return IcebergTableResource(
         name=catalog_name,
-        config=IcebergSqlCatalogConfig(properties=catalog_config_properties),
+        config=IcebergCatalogConfig(properties=catalog_config_properties),
         schema=namespace,
         table=table_name,
     )
@@ -71,62 +71,3 @@ def test_resource(
         [read_table],
         resources={"pyiceberg_table": pyiceberg_table_resource},
     )
-
-
-# def test_resource_versioned(tmp_path):
-#     data = pa.table(
-#         {
-#             "a": pa.array([1, 2, 3], type=pa.int32()),
-#             "b": pa.array([5, 6, 7], type=pa.int32()),
-#         }
-#     )
-
-#     @asset
-#     def create_table(delta_table: DeltaTableResource):
-#         write_deltalake(
-#             delta_table.url, data, storage_options=delta_table.storage_options.str_dict()
-#         )
-#         write_deltalake(
-#             delta_table.url,
-#             data,
-#             storage_options=delta_table.storage_options.str_dict(),
-#             mode="append",
-#         )
-
-#     @asset
-#     def read_table(delta_table: DeltaTableResource):
-#         res = delta_table.load().to_pyarrow_table()
-#         assert res.equals(data)
-
-#     materialize(
-#         [create_table, read_table],
-#         resources={
-#             "delta_table": DeltaTableResource(
-#                 url=os.path.join(tmp_path, "table"), storage_options=LocalConfig(), version=0
-#             )
-#         },
-#     )
-
-
-# @pytest.mark.parametrize(
-#     "config",
-#     [
-#         LocalConfig(),
-#         AzureConfig(account_name="test", use_azure_cli=True),
-#         GcsConfig(bucket="test"),
-#         S3Config(bucket="test"),
-#         ClientConfig(timeout=1),
-#     ],
-# )
-# def test_config_classes_are_string_dicts(tmp_path, config):
-#     data = pa.table(
-#         {
-#             "a": pa.array([1, 2, 3], type=pa.int32()),
-#             "b": pa.array([5, 6, 7], type=pa.int32()),
-#         }
-#     )
-#     config_dict = config.str_dict()
-#     assert all([isinstance(val, str) for val in config_dict.values()])
-#     # passing the config_dict to write_deltalake validates that all dict values are str.
-#     # it will throw an exception if there are other value types
-#     write_deltalake(os.path.join(tmp_path, "table"), data, storage_options=config_dict)


### PR DESCRIPTION
Now supports all catalogs by using `load_catalog()` fn which infers it from the properties.

Closes #15 